### PR TITLE
Fixed logging

### DIFF
--- a/examples/elekta/5_sign_flip.py
+++ b/examples/elekta/5_sign_flip.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
 
     # Find a good template subject to align other subjects to
     template = find_template_subject(
-        src_dir, subjects, n_embeddings=15, standardize=True
+        outdir, subjects, n_embeddings=15, standardize=True
     )
 
     # Settings for batch processing

--- a/osl_ephys/preprocessing/batch.py
+++ b/osl_ephys/preprocessing/batch.py
@@ -812,9 +812,7 @@ def run_proc_chain(
     # Generate log filename
     if logsdir is not None:
         logbase = os.path.join(logsdir, name_base)
-        logfile = logbase.format(
-            run_id=run_id.replace("_raw", ""), ftype=ftype, fext="log"
-        )
+        logfile = logbase.format(run_id=run_id, ftype=ftype.replace("-raw", ""), fext="log")
         mne.utils._logging.set_log_file(logfile, overwrite=overwrite)
     else:
         logfile = None
@@ -838,9 +836,7 @@ def run_proc_chain(
     # Write preprocessed data to output directory
     if outdir is not None:
         # Check for existing outputs - should be a .fif at least
-        fifout = outbase.format(
-            run_id=run_id.replace('_raw', ''), ftype=ftype, fext='fif'
-        )
+        fifout = outbase.format(run_id=run_id, ftype=ftype, fext='fif')
         if os.path.exists(fifout) and (overwrite is False):
             logger.critical('Skipping preprocessing - existing output detected')
             return False
@@ -1050,7 +1046,7 @@ def run_proc_batch(
     if strictrun and verbose not in ['INFO', 'DEBUG']:
         # override logger level if strictrun requested but user won't see any info...
         verobse = 'INFO'
-    logfile = os.path.join(logsdir, 'osl_batch.log')
+    logfile = os.path.join(logsdir, 'batch_preproc.log')
     osl_logger.set_up(log_file=logfile, level=verbose, startup=False)
 
     logger.info('Starting osl-ephys Batch Processing')
@@ -1134,11 +1130,7 @@ def run_proc_batch(
             proc_flags = [flag[0] for flag in proc_flags]
         
         osl_logger.set_up(log_file=logfile, level=verbose, startup=False)
-        logger.info(
-            "Processed {0}/{1} files successfully".format(
-                np.sum(proc_flags), len(proc_flags)
-            )
-        )
+        logger.info("Processed {0}/{1} files successfully".format( np.sum(proc_flags), len(proc_flags)))
         
         # Generate a report
         if gen_report and len(infiles) > 0:

--- a/osl_ephys/source_recon/batch.py
+++ b/osl_ephys/source_recon/batch.py
@@ -315,7 +315,7 @@ def run_src_batch(
 
     # Initialise Loggers
     mne.set_log_level(mneverbose)
-    logfile = os.path.join(logsdir, 'osl_batch.log')
+    logfile = os.path.join(logsdir, 'batch_src.log')
     osl_logger.set_up(log_file=logfile, level=verbose, startup=False)
     logger.info('Starting osl-ephys Batch Source Reconstruction')
 

--- a/osl_ephys/utils/logger.py
+++ b/osl_ephys/utils/logger.py
@@ -4,12 +4,13 @@ Heavily inspired by logging in OSL.
 """
 
 # Authors: Andrew Quinn <a.quinn@bham.ac.uk>
+#          Chetan Gohil <chetan.gohil@psych.ox.ac.uk>
 
 import yaml
 import logging
 
 # Initialise logging for this sub-module
-osl_logger = logging.getLogger("osl")
+osl_logger = logging.getLogger("osl_ephys")
 osl_logger.setLevel(logging.WARNING)
 
 #%% ------------------------------------------------------------
@@ -18,7 +19,7 @@ osl_logger.setLevel(logging.WARNING)
 default_config = """
 version: 1
 loggers:
-  osl:
+  osl_ephys:
     level: DEBUG
     handlers: [console, file]
     propagate: false
@@ -75,7 +76,7 @@ def set_up(prefix='', log_file=None, level=None, console_format=None, startup=Tr
 
     # Remove log file from dict if not user requested
     if log_file is None:
-        new_config['loggers']['osl']['handlers'] = ['console']
+        new_config['loggers']['osl_ephys']['handlers'] = ['console']
         del new_config['handlers']['file']
 
     # Configure osl_logger with dict

--- a/osl_ephys/utils/logger.py
+++ b/osl_ephys/utils/logger.py
@@ -7,15 +7,10 @@ Heavily inspired by logging in OSL.
 
 import yaml
 import logging
-import logging.config
-
-
-# Housekeeping for logging
-# Set logger level to WARNING as default
-logging.getLogger("osl").setLevel(logging.WARNING)
 
 # Initialise logging for this sub-module
-osl_logger = logging.getLogger(__name__)
+osl_logger = logging.getLogger("osl")
+osl_logger.setLevel(logging.WARNING)
 
 #%% ------------------------------------------------------------
 


### PR DESCRIPTION
I think since the package renaming (osl -> osl-ephs) the logging was broken. This is now fixed.

The `osl_batch.log` has been split into two different logs for the preprocessing (`batch_preproc.log`) and source recon (`batch_src.log`).