### PR TITLE
Fix: don't generate a source reconstruction report page for failed runs

### DIFF
--- a/osl_ephys/report/src_report.py
+++ b/osl_ephys/report/src_report.py
@@ -153,7 +153,10 @@ def gen_html_page(reportdir):
         subdir = Path(subdir)
         # Just generate the html page with the successful runs
         try:
-            data.append(pickle.load(open(reportdir / subdir / "data.pkl", "rb")))
+            report_data = pickle.load(open(reportdir / subdir / "data.pkl", "rb"))
+            if "filename" not in report_data:
+                continue
+            data.append(report_data)
         except:
             pass
 


### PR DESCRIPTION
Closes: https://github.com/OHBA-analysis/osl-ephys/issues/390

There as a bug detecting when a source reconstruction run failed. The code tried to make a html report page when it shouldn't. This PR resolves this.