### PR TITLE
feat: local parcel orthogonalisation

### DIFF
--- a/osl_ephys/source_recon/wrappers.py
+++ b/osl_ephys/source_recon/wrappers.py
@@ -879,6 +879,7 @@ def parcellate(
     reference_brain=None,
     voxel_trans="ztrans",
     extra_chans="stim",
+    neighbour_distance=None,
     reportdir=None,
     **kwargs,
 ):
@@ -898,8 +899,9 @@ def parcellate(
         Path to the parcellation file to use.
     method : str
         Method to use in the parcellation.
-    orthogonalisation : bool
-        Should we do orthogonalisation?
+    orthogonalisation : str, None
+        Options are 'symmetric', 'local', None. If 'local', neighbour_distance 
+        must be specified.
     source_space : str
         Source model to use. Can be 'volumetric' (/'vol') or 'surface' (/'surf').
     surface_extraction_method : str
@@ -922,6 +924,9 @@ def parcellate(
         Extra channels to include in the parc-raw.fif file.
         Defaults to 'stim'. Stim channels are always added to parc-raw.fif
         in addition to extra_chans.
+    neighbour_distance : float, optional
+        Distance in mm between parcel centers to consider neighbours 
+        for orthogonalisation='local'.
     reportdir : str, optional
         Path to report directory.
     """
@@ -1077,13 +1082,18 @@ def parcellate(
             )
 
     # Orthogonalisation
-    if orthogonalisation not in [None, "symmetric", "none", "None"]:
+    if orthogonalisation not in [None, "symmetric", "local", "none", "None"]:
         raise NotImplementedError(orthogonalisation)
 
     if orthogonalisation == "symmetric":
         log_or_print(f"{orthogonalisation} orthogonalisation")
         parcel_data = parcellation.symmetric_orthogonalise(
             parcel_data, maintain_magnitudes=True
+        )
+    elif orthogonalisation == "local":
+        log_or_print(f"{orthogonalisation} orthogonalisation")
+        parcel_data = parcellation.local_orthogonalise(
+            parcel_data, parcellation_file, neighbour_distance,
         )
 
     os.makedirs(f"{outdir}/{subject}/parc", exist_ok=True)
@@ -1164,6 +1174,7 @@ def beamform_and_parcellate(
     spatial_resolution=None,
     reference_brain="mni",
     extra_chans="stim",
+    neighbour_distance=None,
     reportdir=None,
 ):
     """Wrapper function for beamforming and parcellation.
@@ -1187,8 +1198,9 @@ def beamform_and_parcellate(
         Path to the parcellation file to use.
     method : str
         Method to use in the parcellation.
-    orthogonalisation : bool
-        Should we do orthogonalisation?
+    orthogonalisation : str, None
+        Options are 'symmetric', 'local', None. If 'local', neighbour_distance 
+        must be specified.
     freq_range : list, optional
         Lower and upper band to bandpass filter before beamforming.
         If None, no filtering is done.
@@ -1216,6 +1228,9 @@ def beamform_and_parcellate(
         Extra channels to include in the parc-raw.fif file.
         Defaults to 'stim'. Stim channels are always added to parc-raw.fif
         in addition to extra_chans.
+    neighbour_distance : float, optional
+        Distance in mm between parcel centers to consider neighbours 
+        for orthogonalisation='local'.
     reportdir : str, optional
         Path to report directory.
     """
@@ -1294,13 +1309,18 @@ def beamform_and_parcellate(
     )
 
     # Orthogonalisation
-    if orthogonalisation not in [None, "symmetric", "none", "None"]:
+    if orthogonalisation not in [None, "symmetric", "local", "none", "None"]:
         raise NotImplementedError(orthogonalisation)
 
     if orthogonalisation == "symmetric":
         log_or_print(f"{orthogonalisation} orthogonalisation")
         parcel_data = parcellation.symmetric_orthogonalise(
             parcel_data, maintain_magnitudes=True
+        )
+    elif orthogonalisation == "local":
+        log_or_print(f"{orthogonalisation} orthogonalisation")
+        parcel_data = parcellation.local_orthogonalise(
+            parcel_data, parcellation_file, neighbour_distance,
         )
 
     if epoch_file is None:
@@ -1390,6 +1410,7 @@ def minimum_norm_and_parcellate(
     reference_brain=None,
     voxel_trans="ztrans",
     extra_chans="stim",
+    neighbour_distance=None,
     reportdir=None,
 ):
     """Wrapper function for minimum_norm and parcellation.
@@ -1416,8 +1437,9 @@ def minimum_norm_and_parcellate(
         Method to use in the parcellation.
     parcellation_file : str
         Path to the parcellation file to use.
-    orthogonalisation : bool
-        Should we do orthogonalisation?
+    orthogonalisation : str, None
+        Options are 'symmetric', 'local', None. If 'local', neighbour_distance 
+        must be specified.
     surface_extraction_method : str, optional
         Method used for surface extraction. Can be 'freesurfer' or 'fsl'.
     depth : float, optional
@@ -1447,6 +1469,9 @@ def minimum_norm_and_parcellate(
         Extra channels to include in the parc-raw.fif file.
         Defaults to 'stim'. Stim channels are always added to parc-raw.fif
         in addition to extra_chans.
+    neighbour_distance : float, optional
+        Distance in mm between parcel centers to consider neighbours 
+        for orthogonalisation='local'.
     reportdir : str, optional
         Path to report directory.
     """
@@ -1562,13 +1587,18 @@ def minimum_norm_and_parcellate(
         )
 
     # Orthogonalisation
-    if orthogonalisation not in [None, "symmetric", "none", "None"]:
+    if orthogonalisation not in [None, "symmetric", "local", "none", "None"]:
         raise NotImplementedError(orthogonalisation)
 
     if orthogonalisation == "symmetric":
         log_or_print(f"{orthogonalisation} orthogonalisation")
         parcel_data = parcellation.symmetric_orthogonalise(
             parcel_data, maintain_magnitudes=True
+        )
+    elif orthogonalisation == "local":
+        log_or_print(f"{orthogonalisation} orthogonalisation")
+        parcel_data = parcellation.local_orthogonalise(
+            parcel_data, parcellation_file, neighbour_distance,
         )
 
     os.makedirs(f"{outdir}/{subject}/parc", exist_ok=True)


### PR DESCRIPTION
Next to the option for symmetric leakage correction of parcel time series, it is now possible to regress out neighbouring parcel's time series from each parcel, based on an adjacency matrix (determined through the distance between parcel centers)