### PR TITLE
Fixed bug plotting parcellated data PSD.

### DIFF
--- a/osl_ephys/source_recon/parcellation.py
+++ b/osl_ephys/source_recon/parcellation.py
@@ -720,12 +720,12 @@ def plot_psd(parc_ts, fs, parcellation_file, filename, freq_range=None, freesurf
         # Calculate PSD for each epoch individually and average
         psd = []
         for i in range(parc_ts.shape[-1]):
-            f, p = welch(parc_ts[..., i], fs=fs, nfft=fs*2)
+            f, p = welch(parc_ts[..., i], fs=fs, nperseg=fs, nfft=fs*2)
             psd.append(p)
         psd = np.mean(psd, axis=0)
     else:
         # Calcualte PSD of continuous data
-        f, psd = welch(parc_ts, fs=fs, nfft=fs*2)
+        f, psd = welch(parc_ts, fs=fs, nperseg=fs, nfft=fs*2)
 
     n_parcels = psd.shape[0]
 


### PR DESCRIPTION
We use scipy's `welch` function to plot the PSD of the parcellated data. The default parameters of this function raise an error if we source reconstruct 100 Hz data. This PR resolves this.